### PR TITLE
Set up dev environment scaffolding + document repo state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Angela-Ye
+
+## Cursor Cloud specific instructions
+
+### Repository state (important, non-obvious)
+
+The default branch (`main`) is currently a **placeholder** — it contains only `README.md`
+and `LICENSE`. There is **no application code, no dependency manifest, no tests, and no
+build/lint/run targets** on `main`. As a result there is nothing to build, lint, test, or
+run from `main` yet.
+
+The intended application — an e‑commerce TikTok video translation / makeup‑transform tool
+(Python) — currently lives only in **unmerged feature branches**:
+
+- `cursor/translate-and-transform-e-commerce-tiktok-videos-2ad3` (Flask `app.py`, Docker, `requirements.txt`)
+- `cursor/translate-and-transform-e-commerce-tiktok-videos-56e9` (`app/` package + `cli.py`)
+- `cursor/translate-and-transform-e-commerce-tiktok-videos-e849` (`src/process_video.py`)
+- `cursor/translate-and-transform-e-commerce-tiktok-videos-eaf1` (Flask `app.py` + `templates/`)
+
+Each of those branches carries its own `requirements.txt` and README with setup/run
+instructions. Consult the specific branch's README before running its code.
+
+### Tooling available in the environment
+
+- Python `3.12` (`python3`, `pip3`)
+- Node.js `22`
+
+### Update script behavior
+
+The startup update script installs Python dependencies **only if** a `requirements.txt`
+exists at the repo root (it is a no‑op on `main`, which has none). When the app code is
+merged into `main` (with a root `requirements.txt`), the update script will begin
+installing those dependencies automatically. If a merged branch uses a different manifest
+location or package manager, update the startup script accordingly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Attempted to set up the development environment for this codebase. The `main` branch is currently a **placeholder** — it contains only `README.md` (`# Angela-Ye`) and `LICENSE`. There is no application code, no dependency manifest, no tests, and no build/lint/run targets on `main`, so there is nothing to build, lint, test, or run from `main` yet.

The intended application (an e‑commerce TikTok video translation / makeup‑transform Python tool) currently exists only in unmerged `cursor/translate-and-transform-e-commerce-tiktok-videos-*` feature branches, each with its own `requirements.txt`.

## Changes

- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting:
  - the placeholder state of `main` and where the real app code lives (unmerged branches),
  - available tooling (Python 3.12, Node 22),
  - the guarded update-script behavior.

## Environment / update script

Registered a minimal, idempotent startup update script that is a no-op today and starts working automatically once app code (with a root `requirements.txt`) is merged:

```
if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
```

## Notes

No application could be run/demonstrated because `main` has no runnable code. Once one of the feature branches is merged into `main`, the environment can be fully set up and the app demonstrated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d835ba64-66de-40b1-9911-4bea931e0856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d835ba64-66de-40b1-9911-4bea931e0856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

