### PR TITLE
Fix Vercel 404 and personalize stories with saved child name

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,14 @@
+app.py
+serve.py
+requirements.txt
+.streamlit/
+services/
+models/
+data/
+scripts/
+test_stories.py
+ui/
+landing/
+assets/
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -28,7 +28,29 @@
 
 5. **Shop CTA** links directly to the doll's product page on appleparkkids.com
 
-## Quick start
+## Deploy the site
+
+### Vercel (recommended for the static site)
+
+1. Import the repo at [vercel.com](https://vercel.com)
+2. Use branch **main** — `vercel.json` and `.vercelignore` deploy only the static HTML/JS/CSS
+3. Your site will be at `https://your-project.vercel.app`
+4. Open **`/story.html`** for Story Time (name + Save + personalized stories)
+
+### GitHub Pages
+
+Pushes to `main` auto-deploy via GitHub Actions to the `gh-pages` branch.
+
+Site URL: `https://angela0922.github.io/Angela-Ye/`
+
+- Home: `index.html`
+- Story Time: `story.html`
+
+### Streamlit app (full chatbot)
+
+Deploy separately on [Streamlit Cloud](https://share.streamlit.io) — point to `app.py`. Vercel cannot run Streamlit.
+
+## Quick start (local)
 
 ### Story chat app (Streamlit)
 

--- a/story.js
+++ b/story.js
@@ -300,6 +300,37 @@ function getStoryPool(character, childName) {
   return pools[character.id];
 }
 
+function getDollFirstName(displayName) {
+  return displayName.split(" ")[0];
+}
+
+/** When a child name is saved, star them in doll stories instead of the doll alone. */
+function personalizeStoryWithChild(story, character, childName) {
+  if (!childName || character.id === "child") {
+    return story;
+  }
+
+  const dollFirst = getDollFirstName(character.displayName);
+  const dollPattern = new RegExp(`\\b${dollFirst.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "g");
+
+  let title = story.title;
+  if (title.includes(dollFirst)) {
+    title = title.replace(dollPattern, childName);
+  } else if (!title.includes(childName)) {
+    title = `${childName}'s ${title}`;
+  }
+
+  const paragraphs = story.paragraphs.map((paragraph, index) => {
+    let text = paragraph.replace(dollPattern, childName);
+    if (index === story.paragraphs.length - 1 && !text.includes(dollFirst)) {
+      text += ` ${dollFirst} cheered for ${childName}.`;
+    }
+    return text;
+  });
+
+  return { title, paragraphs };
+}
+
 function buildRoster(childName) {
   const roster = [...characters];
   if (childName) {
@@ -323,7 +354,11 @@ function renderStory() {
     return;
   }
 
-  const story = pickRandom(stories);
+  const story = personalizeStoryWithChild(
+    pickRandom(stories),
+    character,
+    childName
+  );
   const badge = document.getElementById("character-badge");
   const doll = document.getElementById("story-doll");
   const title = document.getElementById("story-title");
@@ -331,7 +366,11 @@ function renderStory() {
   const card = document.getElementById("story-card");
   const dollClass = character.id === "child" ? "doll-you" : `doll-${character.id}`;
 
-  badge.textContent = `Featuring ${character.displayName}`;
+  if (childName && character.id !== "child") {
+    badge.textContent = `Featuring ${childName} & ${getDollFirstName(character.displayName)}`;
+  } else {
+    badge.textContent = `Featuring ${character.displayName}`;
+  }
   badge.style.background = `${character.color}33`;
   badge.style.color = character.color;
 
@@ -355,7 +394,11 @@ function initSettings() {
   }
 
   saveButton.addEventListener("click", () => {
-    saveChildName(input.value);
+    const name = input.value.trim();
+    if (!name) {
+      return;
+    }
+    saveChildName(name);
     renderStory();
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "buildCommand": "",
+  "outputDirectory": "."
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fix

Resolves Vercel `404: NOT_FOUND` when loading the site.

## Cause

Vercel was trying to deploy the Python/Streamlit app (`app.py`, `requirements.txt`) instead of the static HTML site at the repo root.

## Changes

- **`vercel.json`** — static site output from repo root
- **`.vercelignore`** — excludes Python app files from Vercel build
- **`story.js`** — saved child name (e.g. Angela) now stars in doll stories; badge shows "Featuring Angela & Alex"

## URLs after deploy

- Home: `/` or `/index.html`
- Story Time: `/story.html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b28ff87-7a65-4c46-80ac-9b178310ab95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b28ff87-7a65-4c46-80ac-9b178310ab95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

